### PR TITLE
Revert "Update GitHub actions to build for Ryujinx"

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -11,7 +11,7 @@ inputs:
     required    : false
     default     : ''
   emu:
-    description : 'what system the build is for: Switch, Ryujinx or yuzu'
+    description : 'what system the build is for: Switch or Emulators'
     required    : false
     default     : 'Switch'
 
@@ -62,9 +62,9 @@ runs:
       ;
       cp  -r  ./romfs/  ./starlight_patch_100/atmosphere/contents/0100000000010000/.
   -
-    name  : Yuzu
+    name  : Emulators
     shell : bash
-    if    : ${{ inputs.emu == 'yuzu' }}
+    if    : ${{ inputs.emu == 'Emulators' }}
     run: |
       cd  ./starlight_patch_100/
       mkdir  ./SMOO/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     strategy:
       matrix:
-        emu : [ Switch, Ryujinx ]
+        emu : [ Switch, Emulators ]
     runs-on: ubuntu-latest
     steps:
     -

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -21,11 +21,11 @@ jobs:
   build:
     strategy:
       matrix:
-        emu : [ Switch, Ryujinx, yuzu ]
+        emu : [ Switch, Emulators ]
     runs-on: ubuntu-latest
     outputs:
       filename1: ${{ steps.set-output.outputs.filename-Switch }}
-      filename2: ${{ steps.set-output.outputs.filename-Ryujinx }}
+      filename2: ${{ steps.set-output.outputs.filename-Emulators }}
     steps:
     -
       name : Checkout
@@ -72,7 +72,7 @@ jobs:
         upload_url   : ${{ steps.release.outputs.upload_url }}
         GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
     -
-      name : Attach build artifacts to release (Ryujinx)
+      name : Attach build artifacts to release (Emulators)
       uses : ./.github/actions/attach
       with:
         filename     : ${{ needs.build.outputs.filename2 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,11 @@ jobs:
   build:
     strategy:
       matrix:
-        emu : [ Switch, Ryujinx ]
+        emu : [ Switch, Emulators ]
     runs-on: ubuntu-latest
     outputs:
       filename1: ${{ steps.set-output.outputs.filename-Switch }}
-      filename2: ${{ steps.set-output.outputs.filename-Ryujinx }}
+      filename2: ${{ steps.set-output.outputs.filename-Emulators }}
     steps:
     -
       name : Checkout
@@ -59,7 +59,7 @@ jobs:
         upload_url   : ${{ steps.release.outputs.upload_url }}
         GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
     -
-      name : Attach build artifacts to release (Ryujinx)
+      name : Attach build artifacts to release (Emulators)
       uses : ./.github/actions/attach
       with:
         filename     : ${{ needs.build.outputs.filename2 }}


### PR DESCRIPTION
This reverts commit b3a047a7c5dcd8e74b68e574b739005c7ee87fec.

the reason i want to reverted this is because this is not really the correct way to build for ryujinx, while it does work it won't continue to work as https://github.com/Ryujinx/Ryujinx/pull/4390 will change the way the atmosphere folder works

while it shows up it will hang on booting the game
![image](https://github.com/BinstonWinston/SMO-Prop-Hunt/assets/100526773/1172deac-9d27-4551-89f4-5a39e089a4ab)
![image](https://github.com/BinstonWinston/SMO-Prop-Hunt/assets/100526773/ad4b50b3-9285-4635-a024-cfc59852c979)
unless the change i made in the [original pr for crafty's repo](https://github.com/CraftyBoss/SuperMarioOdysseyOnline/pull/52) is in effect
![image](https://github.com/BinstonWinston/SMO-Prop-Hunt/assets/100526773/80c1c923-18dd-4be9-ac46-a28e31f64288)
![image](https://github.com/BinstonWinston/SMO-Prop-Hunt/assets/100526773/365ba972-2d32-40ff-91e5-0fd7369a125c)

